### PR TITLE
fixing issue with `success` variable

### DIFF
--- a/R/ipapi.R
+++ b/R/ipapi.R
@@ -51,7 +51,7 @@ get_loc <- function(entity=NA) {
   res <- GET(url)
   success <- warn_for_status(res)
 
-  if (success) {
+  if (success$status_code == 200) {
     res_p <- content(res, as = "parsed")
     if (res_p$status != "fail") {
       dat <- data.frame(res_p)

--- a/R/ipapi.R
+++ b/R/ipapi.R
@@ -44,7 +44,7 @@ geolocate <- function(entities, .progress = TRUE) {
 
 get_loc <- function(entity=NA) {
 
-  Sys.sleep(0.15) # help prevent banning
+  Sys.sleep(0.4) # help prevent banning
 
   url <- ifelse(is.na(entity), base_url, paste0(base_url, "/", trim(entity)))
 


### PR DESCRIPTION
The `success` variable isn't a boolean (anymore?  because of `httr` changes?).  In any case, this fixes the issue I encounter when running:

`geolocate(c(NA, "10.0.1.1", "", "72.33.67.89", "dds.ec", " ", "search.twitter.com"),
                        .progress=FALSE)`

`Error in if (success) { : argument is not interpretable as logical`

I've also updated the time delay between requests since I got banned when using `Sys.sleep(0.15)`.  Assuming no latency at all in addition to instantaneous API responses, 0.15*150 requests = 22.5 seconds.  I'm currently using `Sys.sleep(0.4)` which means that 150 requests take >= 60 seconds which is right at the limit that they set.
